### PR TITLE
Added ability to parse queue messages for JSON path

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
         "phpstan/phpstan": "^1.5",
         "ramsey/uuid": "^4.3",
         "squizlabs/php_codesniffer": "^3.6",
-        "guzzlehttp/guzzle": "^7.4"
+        "guzzlehttp/guzzle": "^7.4",
+        "mtdowling/jmespath.php": "^2.6"
     },
     "autoload": {
         "psr-4": {

--- a/src/BehatContext/SqsContext.php
+++ b/src/BehatContext/SqsContext.php
@@ -188,6 +188,32 @@ class SqsContext implements Context
     }
 
     /**
+     * @Then a message with exactly the following JSON path content should have been queued in :queueName:
+     */
+    public function aMessageWithExactlyTheFollowingJSONPathContentShouldHaveBeenQueuedIn(
+        string $queueName,
+        TableNode $table
+    ): void {
+        $this->receiveMessagesFromQueue($queueName);
+
+        $validMessage = false;
+        foreach ($this->queueMessages[$queueName] as $messageContent) {
+            foreach ($table->getRows() as $row) {
+                $searchResult = (string) \JmesPath\Env::search($row[0], $messageContent);
+                if ($searchResult != $row[1]) {
+                    continue 2;
+                }
+            }
+
+            $validMessage = true;
+        }
+
+        if (!$validMessage) {
+            throw new \Exception(sprintf("Message should not have been found in queue '%s'.", $queueName));
+        }
+    }
+
+    /**
      * Read all messages from the given Queue.
      *
      * @param string $queueName


### PR DESCRIPTION
Adde the ability to check a queue for a set of given json path expression and their results:

```
{
	"transaction": "1430409",
	"lines": [{
		"lineId": "1430409",
		"quantity": 2
	}, {
		"lineId": "4313147",
		"quantity": 5
	}]
}
```

```
And a message with exactly the following JSON path content should have been queued in "wmsToNetSuiteReceive":
      | transaction     | 1430409 |
      | length(lines)   | 2       |
      | lines[0].lineId | 1430409 |
```

build-in functions here: https://jmespath.org/proposals/functions.html