### PR TITLE
accept non-zero return code & added test-step to check the last return code

### DIFF
--- a/src/BehatContext/ConsoleContext.php
+++ b/src/BehatContext/ConsoleContext.php
@@ -7,22 +7,20 @@ use Exception;
 
 class ConsoleContext implements Context
 {
+    protected ?int $lastReturnCode = null;
+
     /**
-     * @When I call the console route :arg1
+     * @When I call the console route :route
      * @throws Exception
      */
     public function iCallTheConsoleRoute(string $route): void
     {
         $status = null;
         $output = [];
-        exec(getcwd() . '/console ' . $route, $output, $status);
+        exec(getcwd() . '/console ' . $route, $output, $this->lastReturnCode);
 
         foreach ($output as $outputLine) {
             echo $outputLine . PHP_EOL;
-        }
-
-        if ($status > 0) {
-            throw new \Exception("Command returned a status > 0: " . $status);
         }
 
         if (
@@ -31,6 +29,21 @@ class ConsoleContext implements Context
             str_contains(implode(PHP_EOL, $output), 'error')
         ) {
             throw new Exception("Command triggered a Notice, Warning or Fatal error.");
+        }
+    }
+
+    /**
+     * @Then the last return code should be :expectedReturnCode
+     * @throws Exception
+     */
+    public function theReturnCodeShouldBe(int $expectedReturnCode): void
+    {
+        if ($this->lastReturnCode !== $expectedReturnCode) {
+            throw new Exception(sprintf(
+                'Return code is %s, but expected %s.',
+                $this->lastReturnCode,
+                $expectedReturnCode
+            ));
         }
     }
 }

--- a/src/BehatContext/HalContext.php
+++ b/src/BehatContext/HalContext.php
@@ -266,25 +266,6 @@ class HalContext implements Context
     }
 
     /**
-     * @Then the response collection :collectionName should contain the resources :resourceIds
-     * @throws Exception
-     */
-    public function theResponseCollectionShouldContainTheResources(
-        string $collectionName, string $resourceIds
-    ): void {
-        /** @var stdClass $response */
-        $response = $this->getLastResponseJsonData();
-
-        $collection = $response->_embedded->$collectionName;
-
-        foreach (explode(',', $resourceIds) as $resourceId) {
-            if (!$this->collectionContainsResource($collection, $expectedResource)) {
-                throw new \Exception(sprintf('Resource %s not found.', $resourceId));
-            }
-        }
-    }
-
-    /**
      * @Then the response collection :collectionName should not contain the resource:
      * @throws Exception
      */

--- a/src/BehatContext/HalContext.php
+++ b/src/BehatContext/HalContext.php
@@ -266,6 +266,25 @@ class HalContext implements Context
     }
 
     /**
+     * @Then the response collection :collectionName should contain the resources :resourceIds
+     * @throws Exception
+     */
+    public function theResponseCollectionShouldContainTheResources(
+        string $collectionName, string $resourceIds
+    ): void {
+        /** @var stdClass $response */
+        $response = $this->getLastResponseJsonData();
+
+        $collection = $response->_embedded->$collectionName;
+
+        foreach (explode(',', $resourceIds) as $resourceId) {
+            if (!$this->collectionContainsResource($collection, $expectedResource)) {
+                throw new \Exception(sprintf('Resource %s not found.', $resourceId));
+            }
+        }
+    }
+
+    /**
      * @Then the response collection :collectionName should not contain the resource:
      * @throws Exception
      */


### PR DESCRIPTION
no longer trigger automatically an error if the console command returns a non-zero return code. This made it impossible to test errors from NetSuite for example. Therefore, I also added a test step to check the last return code.